### PR TITLE
Fix behaviour for Cue mode = Mixxx / Pioneer

### DIFF
--- a/Hercules-DJControl-Inpulse-500-script.js
+++ b/Hercules-DJControl-Inpulse-500-script.js
@@ -302,10 +302,10 @@ DJCi500.Deck = function (deckNumbers, midiChannel) {
                 1,//((status & 0xF0) !=== 0x80 && value > 0),
                 54);
             } else {
-              engine.setValue(deckData.currentDeck, "play", false);
+              engine.toggleControl(deckData.currentDeck, "play");
             }
           } else {
-            engine.setValue(deckData.currentDeck, "play", true);
+            engine.toggleControl(deckData.currentDeck, "play");
           }
         }
       };


### PR DESCRIPTION
When setting Cue Mode to Mixxx or Pioneer, pressing play while holding cue doesn't have the expected behaviour.

I looked at a different mapping (https://github.com/Ev3nt1ne/herimp-500map/blob/main/Hercules-DJControl-Inpulse-500-script.js) and noticed that the play button toggling the value instead of just setting it to true or false.
After making the change and using toggleControl here instead of setValue, we got the desired behaviour.


Note: I made this change at a request of a friend and decided to make a PR after we confirmed that it works