### PR TITLE
Fix no toggle command

### DIFF
--- a/Hercules-DJControl-Inpulse-500-script.js
+++ b/Hercules-DJControl-Inpulse-500-script.js
@@ -643,7 +643,8 @@ DJCi500.Deck = function (deckNumbers, midiChannel) {
     off: pairColorsOff[0],
     input: function (channel, control, value, status, group) {
       if (value === 0x7F){
-        engine.setValue(group, "pitch_adjust", -2.0);
+        engine.setValue(group, "pitch_down", 1);
+        engine.setValue(group, "pitch_down", 1);
         midi.sendShortMsg(status, control, this.on);
       }
       else {
@@ -688,7 +689,8 @@ DJCi500.Deck = function (deckNumbers, midiChannel) {
     off: pairColorsOff[3],
     input: function (channel, control, value, status, group) {
       if (value === 0x7F){
-        engine.setValue(group, "pitch_adjust", 2.0);
+        engine.setValue(group, "pitch_up", 1);
+        engine.setValue(group, "pitch_up", 1);
         midi.sendShortMsg(status, control, this.on);
       }
       else {

--- a/Hercules-DJControl-Inpulse-500-script.js
+++ b/Hercules-DJControl-Inpulse-500-script.js
@@ -302,10 +302,10 @@ DJCi500.Deck = function (deckNumbers, midiChannel) {
                 1,//((status & 0xF0) !=== 0x80 && value > 0),
                 54);
             } else {
-              engine.toggleControl(deckData.currentDeck, "play");
+              engine.setValue(group, 'play', ! (engine.getValue(group, 'play')))
             }
           } else {
-            engine.toggleControl(deckData.currentDeck, "play");
+            engine.setValue(group, 'play', ! (engine.getValue(group, 'play')))
           }
         }
       };


### PR DESCRIPTION
Fix an issue on Mixxx 2.4.1 where the layout is using a legacy interface :question: where `toggleCommand` causes an immediate failure.

```
Uncaught exception: file:///home/icedquinn/.mixxx/controllers/Hercules-DJControl-Inpulse-500-script.js:308: TypeError: Property 'toggleControl' of object ControllerScriptInterfaceLegacy(0x7f61380e9680) is not a function
Backtrace: @file:///home/icedquinn/.mixxx/controllers/Hercules-DJControl-Inpulse-500-script.js:308
@:1
```

This just replaces `toggleCommand` with the equivalent used elsewhere in the file.